### PR TITLE
New status and parentheses toggle

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
 		"main": {
 			"activity": "on",
 			"card_count": "on",
+			"card_count_parens": "on",
 			"count_deck": "off",
 			"counts": ["new", "learn", "review"],
 			"deck_name": "on",
@@ -15,7 +16,8 @@
 			"reviewing_status": "Daily reviews",
 			"browsing_status": "Browsing decks",
 			"editing_status": "Adding cards",
-			"no_cards_left_txt": "No cards left"
+			"no_cards_left_txt": "No cards left",
+			"menu_status_no_cards": "Feeling good"
 		}
 	}
 }

--- a/config.md
+++ b/config.md
@@ -7,6 +7,8 @@
 >**card_count**: Display cards left for today as the second field.<br>
 >*(<card amount\> cards left)*
 
+>**card_count_parens**: (Does nothing if card_count is off) Display parentheses around card count.<br>
+
 >**count_deck**: Display cards left only for the last active deck instead of all of them. No effect if card_count is off.
 
 >**counts**: Set which counts to sum up for the 'cards left' (2nd) field. (["new", "learn", "review"], which are the blue, red, green numbers respectively) Simply remove any that you don't want to be tracked from the list.
@@ -34,3 +36,5 @@ If you want the 1st field to be empty for a certain state, set it to "&nbsp;&nbs
 >**editing_status**: Text to display when editing/adding cards (Adding cards)
 
 >**no_cards_left_txt**: (Only works if card_count is on) Text to display when cards left to study/review is 0 (No cards left)
+
+>**menu_status_no_cards**: (Only works if card_count is on) Text to display when in menu and cards left to study/review is 0 (Feeling good)

--- a/config.md
+++ b/config.md
@@ -7,7 +7,7 @@
 >**card_count**: Display cards left for today as the second field.<br>
 >*(<card amount\> cards left)*
 
->**card_count_parens**: (Does nothing if card_count is off) Display parentheses around card count.<br>
+>**card_count_parens**: (Does nothing if card_count is off) Display parentheses around card count.
 
 >**count_deck**: Display cards left only for the last active deck instead of all of them. No effect if card_count is off.
 

--- a/src/main.py
+++ b/src/main.py
@@ -179,14 +179,22 @@ class Ankicord():
         except AttributeError as ex:
             print("Deck doesn't have the expected attributes:", ex)
 
+        card_count_parens = self.__cfg_val(self.main_cfg, 'card_count_parens', bool)
+        
+        paren_left = ""
+        paren_right = ""
+        if card_count_parens:
+            paren_left = "("
+            paren_right = ")"
+        
         if due_count == 0:
             self.rpc_next_state = self.__cfg_val(self.status_cfg,
                                                  'no_cards_left_txt',
                                                  str)
         elif due_count == 1:
-            self.rpc_next_state = "(" + str(due_count) + " card left)"
+            self.rpc_next_state = paren_left + str(due_count) + " card left" + paren_right
         else:
-            self.rpc_next_state = "(" + str(due_count) + " cards left)"
+            self.rpc_next_state = paren_left + str(due_count) + " cards left" + paren_right
 
     def on_state(self, state, _old_state):
         """Take current state and old_state from hook; If browsing, skip
@@ -199,8 +207,15 @@ class Ankicord():
             return
 
         if state == "deckBrowser":
-            self.rpc_next_details = self.__cfg_val(self.status_cfg,
+            if self.rpc_next_state != self.__cfg_val(self.status_cfg,
+                                                 'no_cards_left_txt',
+                                                 str):
+                self.rpc_next_details = self.__cfg_val(self.status_cfg,
                                                    'menu_status',
+                                                   str)
+            else:
+                self.rpc_next_details = self.__cfg_val(self.status_cfg,
+                                                   'menu_status_no_cards',
                                                    str)
 
         elif state == "review":


### PR DESCRIPTION
Some small changes I made myself that others might like. Adds a new status when in menu with no cards left and the option to toggle the parentheses around deck_count on or off. Implementation might not be perfect. Modified config.json and config.md to reflect changes.

I'm new to GitHub. Sorry if I messed something up somehow.

PS: My reasoning behind the first change is that I didn't like the addon displaying "slacking off" when I didn't have any cards left. Sure, I could add more, but maybe I just studied 500. At that point, I'm feeling good. I also just didn't like the deck_count parentheses (seems unnecessary to me) and would edit them out of main.py manually, but this would allow others to turn them off without any coding experience.